### PR TITLE
corrected deletion of barrel files to catch all deletions

### DIFF
--- a/tofu_vstorage_2/scripts/4_world/tofu_vstorage_barrel.c
+++ b/tofu_vstorage_2/scripts/4_world/tofu_vstorage_barrel.c
@@ -728,7 +728,7 @@ modded class Barrel_ColorBase
 		super.EEHealthLevelChanged(oldLevel,newLevel,zone);
 	}
 	
-	override void Delete()
+	override void EEDelete(EntityAI parent)
 	{
 		string filename = vst_neo_get_save_filename();
 		
@@ -743,7 +743,7 @@ modded class Barrel_ColorBase
 		{
 			DeleteFile(filename);
 		}
-		super.Delete();
+		super.EEDelete(parent);
 	}
 	
 	override bool EEOnDamageCalculated(TotalDamageResult damageResult, int damageType, EntityAI source, int component, string dmgZone, string ammo, vector modelPos, float speedCoef)


### PR DESCRIPTION
Moved deletion of barrel files to EEDelete. Previous override of "Delete" only caught explicit delete calls, not CE cleanup or other deletion events. This should catch them all.