### PR TITLE
Can now disable protections

### DIFF
--- a/tofu_vstorage_2/scripts/3_game/vst_config.c
+++ b/tofu_vstorage_2/scripts/3_game/vst_config.c
@@ -21,6 +21,8 @@ class VST_Config
 	
 	protected int max_barrels_per_player = 0; // set to 0 to not limit
 	
+	protected bool disable_barrel_protection = false;
+	
 	protected ref array<string> Blacklist;
 	protected ref array<string> Admins;
 
@@ -136,6 +138,8 @@ class VST_Config
 		min_distance_from_spawn_to_lock = 50.0;
 		
 		max_barrels_per_player = 0;
+		
+		disable_barrel_protection = false;
 		
 		Blacklist = new array<string>;
 		Blacklist.Insert("WrittenNote");
@@ -403,5 +407,14 @@ class VST_Config
 		max_barrels_per_player = newmaxbarrels;
 	}
 
+	bool Get_disable_barrel_protection()
+	{
+		return disable_barrel_protection;
+	}
+	
+	void Set_disable_barrel_protection(bool disable)
+	{
+		disable_barrel_protection = disable;
+	}
 	
 };

--- a/tofu_vstorage_2/scripts/4_world/actionclosebarrel.c
+++ b/tofu_vstorage_2/scripts/4_world/actionclosebarrel.c
@@ -25,7 +25,7 @@ modded class ActionCloseBarrel
 		
 		if( ntarget )
 		{
-			if (ntarget.canInteract(playerID) || ntarget.canInteractAdmin(playerID))
+			if (ntarget.canInteract(playerID) || ntarget.canInteractAdmin(playerID) || ntarget.isProtectionDisabled())
 			{
 				if (ntarget.vst_neo_check_cooldown_and_notify(playerID))
 				{

--- a/tofu_vstorage_2/scripts/4_world/actionopenbarrel.c
+++ b/tofu_vstorage_2/scripts/4_world/actionopenbarrel.c
@@ -25,7 +25,7 @@ modded class ActionOpenBarrel
 		
 		if( ntarget )
 		{
-			if (ntarget.canInteract(playerID) || ntarget.canInteractAdmin(playerID))
+			if (ntarget.canInteract(playerID) || ntarget.canInteractAdmin(playerID) || ntarget.isProtectionDisabled())
 			{
 				if (ntarget.vst_neo_check_cooldown_and_notify(playerID))
 				{


### PR DESCRIPTION
Also set protection disabled check after canInteractAdmin check to allow for barrel owner prints to still work